### PR TITLE
:arrow_down: openjfx 17.0.8

### DIFF
--- a/ihmc-parameter-tuner/build.gradle.kts
+++ b/ihmc-parameter-tuner/build.gradle.kts
@@ -18,7 +18,7 @@ mainDependencies {
    api("us.ihmc:ihmc-javafx-toolkit:17-0.22.11")
    api("us.ihmc:simulation-construction-set-utilities:0.25.2")
 
-   var javaFXVersion = "17.0.9"
+   var javaFXVersion = "17.0.8"
    api(ihmc.javaFXModule("base", javaFXVersion))
    api(ihmc.javaFXModule("controls", javaFXVersion))
    api(ihmc.javaFXModule("graphics", javaFXVersion))


### PR DESCRIPTION
I am proposing to downgrade to 17.0.8 from 17.0.9.

17.0.9 has an incomplete artifact set. It is missing artifacts for linux-arm64.

[17.0.8](https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/17.0.8/)
[17.0.9](https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/17.0.9/)