### PR TITLE
[Cleanup] Moved HandJointName to ihmc-robotics-tools

### DIFF
--- a/ihmc-robotics-tools/src/main/java/us/ihmc/robotics/partNames/HandJointName.java
+++ b/ihmc-robotics-tools/src/main/java/us/ihmc/robotics/partNames/HandJointName.java
@@ -1,0 +1,39 @@
+package us.ihmc.robotics.partNames;
+
+import us.ihmc.robotics.robotSide.RobotSide;
+
+public interface HandJointName
+{
+   /**
+    * Retrieves the name of the finger to which this joint belongs.
+    *
+    * @param robotSide refers to which hand this joint belongs.
+    * @return the finger name.
+    */
+   FingerName getFinger(RobotSide robotSide);
+
+   /**
+    * Provides a side-dependent index for this joint that contained in [0, N], where N is the number
+    * of hand joints.
+    *
+    * @param robotSide refers to which hand this joint belongs.
+    * @return the index associated with this joint.
+    */
+   int getIndex(RobotSide robotSide);
+
+   /**
+    * Get the {@code HandJointName} for all the finger joints for one hand.
+    *
+    * @return the array containing all the joint names.
+    */
+   HandJointName[] getValues();
+
+   /**
+    * Retrieves the joint name as a {@code String} that corresponds to the joint name as defined in
+    * the robot definition, i.e. the SDF/URDF model or the {@code RobotDescription}.
+    *
+    * @param robotSide refers to which hand this joint belongs.
+    * @return the {@code String} of this joint name.
+    */
+   String getJointName(RobotSide robotSide);
+}


### PR DESCRIPTION
Need to get this out of open robotics so it can be used in ihmc_hands_ros2. This seems like a natural place for it, along with all the other `*Name` classes.